### PR TITLE
Habilitando requisições entre servidor e cliente

### DIFF
--- a/src/client/airplanedocgenerator/src/utils/ServerRequester.js
+++ b/src/client/airplanedocgenerator/src/utils/ServerRequester.js
@@ -6,7 +6,7 @@
  class ServerRequester{
     constructor(){
         // URL do servidor
-        this.serverURL = window.location.protocol + "//" + window.location.host;
+        this.serverURL = window.location.protocol + "//" + window.location.hostname + ":8080" ;
 
     }
     
@@ -41,7 +41,7 @@
         }
 
         // Faz a requisição para a URL construída e obtêm sua resposta como JSON
-        return await this.fazerRequisicao(url, requestConfigs);
+        return await this.doRequest(url, requestConfigs);
     }
 
     /**
@@ -57,10 +57,7 @@
 
         let requestConfigs = {
                             method: "POST",
-                            body: JSON.stringify(data),
-                            headers: {
-                                "Content-Type": contentType   
-                                }
+                            body: JSON.stringify(data)
                         };
 
         // Faz a requisição para a URL construída e obtêm sua resposta como JSON
@@ -79,19 +76,20 @@
      * @returns JSON - Retorna um objeto JSON contendo a resposta do servidor para o serviço solicitado 
      */
     async doRequest(url, requestConfigs){
-        let requisicao = await fetch(url, requestConfigs);
+        let request = await fetch(url, requestConfigs);
 
         let response = {};
 
-        try{
-            let responseJson = await requisicao.json();
+        response["ok"] = request.ok;
+        response["status"] = request.status;
 
-            response["ok"] = requisicao.ok;
-            response["status"] = requisicao.status;
+        try {
+            let responseJson = await request.json();
+
             response["responseJson"] = responseJson;
 
-        }catch(e){
-            console.log("Requisição sem retorno");
+        } catch (error){
+            response["responseJson"] = error.message;
 
         }
 

--- a/src/client/airplanedocgenerator/src/utils/ServerRequester.js
+++ b/src/client/airplanedocgenerator/src/utils/ServerRequester.js
@@ -1,0 +1,103 @@
+/**
+ * Classe responsável por administrar e facilitar todas as requisições RESTs feitas ao servidor
+ * 
+ * @author Rafael Furtado
+ */
+ class ServerRequester{
+    constructor(){
+        // URL do servidor
+        this.serverURL = window.location.protocol + "//" + window.location.host;
+
+    }
+    
+
+
+    async doGet(restPath, parameters){
+        let url = this.serverURL + restPath;
+
+        let requestConfigs = {
+            method: "GET"
+        }
+
+        // Verifica se foram passados parâmetros para a requisição
+        if(parameters !== undefined){
+            // Cria um array com as chaves do JSON parametros
+            let parametersKeys = Object.keys(parameters);
+
+            // Adiciona "?" após a URL, para iniciar a inserção dos parâmetros da requisição
+            url += "?";
+
+            // Itera pelos parâmetros e os adiciona à URL
+            for (let i = 0; i < parametersKeys.length; i++) {
+                const chave = parametersKeys[i];
+                
+                url += chave + "=" + parameters[chave] + "&";
+
+            }
+
+            // Retira o último "&" da url de requisição
+            url = url.slice(0, url.length - 1);
+
+        }
+
+        // Faz a requisição para a URL construída e obtêm sua resposta como JSON
+        return await this.fazerRequisicao(url, requestConfigs);
+    }
+
+    /**
+     * Faz uma requisição POST para o servidor, para o serviço REST específicado e com os dados fornecidos
+     * 
+     * @author Rafael Furtado
+     * @param {String} caminhoRest - Rota de acesso ao serviço REST, por exemplo /rest/texto
+     * @param {Object} data - JSON com parâmetros para a requisição, no formato chave:valor
+     * @returns JSON - Retorna um objeto JSON contendo a resposta do servidor para o serviço solicitado
+     */
+    async doPost(restPath, data = {}, contentType = "application/json"){
+        let url = this.serverURL + restPath;
+
+        let requestConfigs = {
+                            method: "POST",
+                            body: JSON.stringify(data),
+                            headers: {
+                                "Content-Type": contentType   
+                                }
+                        };
+
+        // Faz a requisição para a URL construída e obtêm sua resposta como JSON
+        return await this.doRequest(url, requestConfigs);
+    }
+
+    /**
+     * MÉTODO PRIVADO
+     * 
+     * Utilizado pela classe ServerRequester para reaproveitar a parte igual que as
+     * requisições tem, independente do método
+     * 
+     * @author Rafael Furtado
+     * @param {String} url - URL para fazer a solicitação
+     * @param {Object} configs - Configurações para o método de solicitação
+     * @returns JSON - Retorna um objeto JSON contendo a resposta do servidor para o serviço solicitado 
+     */
+    async doRequest(url, requestConfigs){
+        let requisicao = await fetch(url, requestConfigs);
+
+        let response = {};
+
+        try{
+            let responseJson = await requisicao.json();
+
+            response["ok"] = requisicao.ok;
+            response["status"] = requisicao.status;
+            response["responseJson"] = responseJson;
+
+        }catch(e){
+            console.log("Requisição sem retorno");
+
+        }
+
+        return response;
+    }
+
+}
+
+export default ServerRequester;

--- a/src/client/airplanedocgenerator/src/utils/ServerRequester.js
+++ b/src/client/airplanedocgenerator/src/utils/ServerRequester.js
@@ -12,6 +12,17 @@
     
 
 
+    /**
+     * Função para realizar requisições do tipo GET ao servidor da aplicação
+     * 
+     * @param {String} restPath Caminho do servidor REST para acessar o serviço, no formato "/caminho/do/servico"
+     * @param {JSON} parameters JSON contendo os parâmetros para a requisição, onde a chave deve ser o nome do atributo
+     *                          e o valor, o seu valor a ser associado na URL
+     * @returns Retorna um objeto JSON contendo a resposta da requisição, com as seguintes chaves disponíveis:
+     *  - ok -> Boolean - Informa se a requisição teve sucesso ou não, 
+     *  - status -> Number - Código HTTP informando o status da requisição
+     *  - responseJson -> JSON - Objeto JSON retornado do servidor
+     */
     async doGet(restPath, parameters){
         let url = this.serverURL + restPath;
 
@@ -49,10 +60,13 @@
      * 
      * @author Rafael Furtado
      * @param {String} caminhoRest - Rota de acesso ao serviço REST, por exemplo /rest/texto
-     * @param {Object} data - JSON com parâmetros para a requisição, no formato chave:valor
-     * @returns JSON - Retorna um objeto JSON contendo a resposta do servidor para o serviço solicitado
+     * @param {JSON} data - JSON com parâmetros para a requisição, no formato chave:valor
+     * @returns Retorna um objeto JSON contendo a resposta da requisição, com as seguintes chaves disponíveis:
+     *  - ok -> Boolean - Informa se a requisição teve sucesso ou não, 
+     *  - status -> Number - Código HTTP informando o status da requisição
+     *  - responseJson -> JSON - Objeto JSON retornado do servidor
      */
-    async doPost(restPath, data = {}, contentType = "application/json"){
+    async doPost(restPath, data = {}){
         let url = this.serverURL + restPath;
 
         let requestConfigs = {

--- a/src/server/AirplaneManualGenerator/pom.xml
+++ b/src/server/AirplaneManualGenerator/pom.xml
@@ -44,7 +44,12 @@
 		    <version>0.4</version>
 		</dependency>
 		
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<scope>runtime</scope>
+			<optional>true</optional>
+		</dependency>
 		
 	</dependencies>
 

--- a/src/server/AirplaneManualGenerator/src/main/java/api/crabteam/filters/AuthenticationFilter.java
+++ b/src/server/AirplaneManualGenerator/src/main/java/api/crabteam/filters/AuthenticationFilter.java
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Component;
  * @author Rafael Furtado
  */
 @Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
 public class AuthenticationFilter implements Filter {
 
 	@Override

--- a/src/server/AirplaneManualGenerator/src/main/java/api/crabteam/filters/CORSFilter.java
+++ b/src/server/AirplaneManualGenerator/src/main/java/api/crabteam/filters/CORSFilter.java
@@ -1,0 +1,38 @@
+package api.crabteam.filters;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+
+
+/**
+ * Filtro de política de CORS, para permitir que a aplicação cliente receba a resposta do servidor
+ * 
+ * @author Rafael Furtado
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CORSFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		HttpServletResponse httpResponse = (HttpServletResponse) response;
+		
+		httpResponse.addHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+		
+		chain.doFilter(request, response);
+		
+	}
+
+}


### PR DESCRIPTION
A classe ServerRequester foi criada no cliente para permitir as requisições ao servidor e o filtro de CORS foi adicionado ao servidor para permitir que o cliente receba as respostas

Foi testado com uma classe de testes que não foi adicionada ao repositório, eventuais testes concretos serão feitos quando existirem serviços disponíveis

**_Apagar a branch após aceitar o PR_**